### PR TITLE
Fix slider style in Firefox browser

### DIFF
--- a/src/component/model/COIAS/ContrastBar.jsx
+++ b/src/component/model/COIAS/ContrastBar.jsx
@@ -24,6 +24,7 @@ function ContrastBar({ val, set }) {
         min="0"
         max="300"
         data-slider-step="1"
+        orient="vertical"
         value={val.toString()}
         onChange={(e) => {
           set(Number(e.target.value));

--- a/src/component/ui/BrightnessBar.jsx
+++ b/src/component/ui/BrightnessBar.jsx
@@ -24,6 +24,7 @@ function BrightnessBar({ val, set }) {
         min="0"
         max="300"
         data-slider-step="1"
+        orient="vertical"
         value={val.toString()}
         onChange={(e) => {
           set(Number(e.target.value));


### PR DESCRIPTION
fix #85

Added `orient="vertical"` attributes to ContrastBar, BrightnessBar